### PR TITLE
Adjust tests to a more realistic expectation

### DIFF
--- a/benchmarks/FusionCache.Plugins.Metrics.AppMetrics.Benchmarks/FusionCache.Plugins.Metrics.AppMetrics.Benchmarks.csproj
+++ b/benchmarks/FusionCache.Plugins.Metrics.AppMetrics.Benchmarks/FusionCache.Plugins.Metrics.AppMetrics.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net60</TargetFramework>
     <RootNamespace>ZiggyCreatures.Fusion.Caching.Plugins.AppMetrics.Benchmarks</RootNamespace>
     <AssemblyName>FusionCache.Plugins.Metrics.AppMetrics.Benchmarks</AssemblyName>
   </PropertyGroup>

--- a/benchmarks/FusionCache.Plugins.Metrics.EventCounters.Benchmarks/FusionCache.Plugins.Metrics.EventCounters.Benchmarks.csproj
+++ b/benchmarks/FusionCache.Plugins.Metrics.EventCounters.Benchmarks/FusionCache.Plugins.Metrics.EventCounters.Benchmarks.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net60</TargetFramework>
     <RootNamespace>ZiggyCreatures.Fusion.Caching.Plugins.EventCounters.Benchmarks</RootNamespace>
     <AssemblyName>FusionCache.Plugins.Metrics.EventCounters.Benchmarks</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.1.9" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/AppMetricsPluginExampleDotNetCore/AppMetricsPluginExampleDotNetCore.csproj
+++ b/examples/AppMetricsPluginExampleDotNetCore/AppMetricsPluginExampleDotNetCore.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="App.Metrics.Reporting.TextFile" Version="4.3.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.1.9" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/AppMetricsPluginExampleFramework/AppMetricsPluginExampleFramework.csproj
+++ b/examples/AppMetricsPluginExampleFramework/AppMetricsPluginExampleFramework.csproj
@@ -411,8 +411,8 @@
       <HintPath>..\..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
-    <Reference Include="ZiggyCreatures.FusionCache, Version=0.1.9.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ZiggyCreatures.FusionCache.0.1.9\lib\netstandard2.0\ZiggyCreatures.FusionCache.dll</HintPath>
+    <Reference Include="ZiggyCreatures.FusionCache, Version=0.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ZiggyCreatures.FusionCache.0.9.0\lib\netstandard2.0\ZiggyCreatures.FusionCache.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/examples/AppMetricsPluginExampleFramework/packages.config
+++ b/examples/AppMetricsPluginExampleFramework/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net472" />
   <package id="App.Metrics" version="4.3.0" targetFramework="net472" />
@@ -115,5 +115,5 @@
   <package id="System.Xml.ReaderWriter" version="4.3.1" targetFramework="net472" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net472" />
   <package id="WebGrease" version="1.6.0" targetFramework="net472" />
-  <package id="ZiggyCreatures.FusionCache" version="0.1.9" targetFramework="net472" />
+  <package id="ZiggyCreatures.FusionCache" version="0.9.0" targetFramework="net472" />
 </packages>

--- a/examples/AppMetricsPluginExampleFrameworkOnAspNetCore/AppMetricsPluginExampleFrameworkOnAspNetCore.csproj
+++ b/examples/AppMetricsPluginExampleFrameworkOnAspNetCore/AppMetricsPluginExampleFrameworkOnAspNetCore.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Serilog.Settings.AppSettings" Version="2.2.2" />
     <PackageReference Include="System.Text.Json" Version="6.0.2" />
-    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.1.9" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/EventCountersPluginExampleDotNetCore/EventCountersPluginExampleDotNetCore.csproj
+++ b/examples/EventCountersPluginExampleDotNetCore/EventCountersPluginExampleDotNetCore.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="InfluxDB.Client" Version="3.3.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.1.9" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FusionCache.Plugins.Metrics.AppMetrics/FusionCache.Plugins.Metrics.AppMetrics.csproj
+++ b/src/FusionCache.Plugins.Metrics.AppMetrics/FusionCache.Plugins.Metrics.AppMetrics.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="App.Metrics" Version="4.3.0" />
-    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.1.9" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FusionCache.Plugins.Metrics.EventCounters/FusionCache.Plugins.Metrics.EventCounters.csproj
+++ b/src/FusionCache.Plugins.Metrics.EventCounters/FusionCache.Plugins.Metrics.EventCounters.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.1.9" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/FusionCache.Plugins.Metrics.AppMetrics.Tests/AppMetricsTests.cs
+++ b/tests/FusionCache.Plugins.Metrics.AppMetrics.Tests/AppMetricsTests.cs
@@ -104,7 +104,6 @@ namespace ZiggyCreatures.Caching.Fusion.Plugins.Metrics.AppMetrics.Tests
 
                     // HIT (STALE): +1
                     // FAIL-SAFE: +1
-                    // SET: +1
                     _ = await cache.GetOrSetAsync<int>("foo", _ => throw new Exception("Sloths are cool"));
 
                     // MISS: +1
@@ -116,7 +115,6 @@ namespace ZiggyCreatures.Caching.Fusion.Plugins.Metrics.AppMetrics.Tests
 
                     // HIT (STALE): +1
                     // FAIL-SAFE: +1
-                    // SET: +1
                     _ = await cache.GetOrSetAsync<int>("foo", _ => throw new Exception("Sloths are cool"));
 
                     // REMOVE: +1
@@ -143,7 +141,7 @@ namespace ZiggyCreatures.Caching.Fusion.Plugins.Metrics.AppMetrics.Tests
                     Assert.Equal(3, GetMetric(messages, SemanticConventions.Instance().CacheMissTagValue));
                     Assert.Equal(2, GetMetric(messages, SemanticConventions.Instance().CacheHitTagValue));
                     Assert.Equal(2, GetMetric(messages, SemanticConventions.Instance().CacheStaleHitTagValue));
-                    Assert.Equal(3, GetMetric(messages, SemanticConventions.Instance().CacheSetTagValue));
+                    Assert.Equal(1, GetMetric(messages, SemanticConventions.Instance().CacheSetTagValue));
                     Assert.Equal(2, GetMetric(messages, SemanticConventions.Instance().CacheRemovedTagValue));
                     Assert.Equal(2, GetMetric(messages, SemanticConventions.Instance().CacheFailSafeActivateTagValue));
                 }
@@ -265,10 +263,9 @@ namespace ZiggyCreatures.Caching.Fusion.Plugins.Metrics.AppMetrics.Tests
 
                     // INITIAL, NON-TRACKED SET
                     await cache.SetAsync<int>("foo", 42);
-
-                    // LET IT BECOME STALE
+                     // LET IT BECOME STALE
                     await Task.Delay(throttleDuration);
-
+                    
                     // HIT (STALE): +1
                     // FAIL-SAFE: +1
                     // SET: +1
@@ -278,14 +275,12 @@ namespace ZiggyCreatures.Caching.Fusion.Plugins.Metrics.AppMetrics.Tests
                         return 42;
                     });
 
-
                     //await cache.SetAsync<int>("foo", 42);
                     // LET IT BECOME STALE
                     await Task.Delay(throttleDuration);
-
+                    
                     // HIT (STALE): +1
                     // FAIL-SAFE: +1
-                    // SET: +1
                     // STALE_REFRESH_ERROR: +1
                     _ = await cache.GetOrSetAsync<int>("foo", async _ =>
                     {
@@ -296,14 +291,13 @@ namespace ZiggyCreatures.Caching.Fusion.Plugins.Metrics.AppMetrics.Tests
 
                     // Let EventListener poll for data
                     await Task.Delay(1000);
-
-
+                    
                     var messages = reporter.Messages.ToList();
                     // messages.ForEach(c => _testOutputHelper.WriteLine(c.ToString()));
 
                     Assert.Equal(0, GetMetric(messages, SemanticConventions.Instance().CacheHitTagValue));
                     Assert.Equal(2, GetMetric(messages, SemanticConventions.Instance().CacheFailSafeActivateTagValue));
-                    Assert.Equal(3, GetMetric(messages, SemanticConventions.Instance().CacheSetTagValue));
+                    Assert.Equal(2, GetMetric(messages, SemanticConventions.Instance().CacheSetTagValue));
                     Assert.Equal(2, GetMetric(messages, SemanticConventions.Instance().CacheStaleHitTagValue));
                     Assert.Equal(1, GetMetric(messages, SemanticConventions.Instance().CacheBackgroundRefreshedTagValue));
                     Assert.Equal(1, GetMetric(messages, SemanticConventions.Instance().CacheBackgroundFailedRefreshedTagValue));

--- a/tests/FusionCache.Plugins.Metrics.AppMetrics.Tests/FusionCache.Plugins.Metrics.AppMetrics.Tests.csproj
+++ b/tests/FusionCache.Plugins.Metrics.AppMetrics.Tests/FusionCache.Plugins.Metrics.AppMetrics.Tests.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.1.9" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/FusionCache.Plugins.Metrics.EventCounters.Tests/EventCountersTests.cs
+++ b/tests/FusionCache.Plugins.Metrics.EventCounters.Tests/EventCountersTests.cs
@@ -246,7 +246,6 @@ namespace ZiggyCreatures.Caching.Fusion.Plugins.EventCounters.Tests
 
                 // HIT (STALE): +1
                 // FAIL-SAFE: +1
-                // SET: +1
                 _ = await cache.GetOrSetAsync<int>("foo", _ => throw new Exception("Sloths are cool"));
 
                 // MISS: +1
@@ -258,7 +257,6 @@ namespace ZiggyCreatures.Caching.Fusion.Plugins.EventCounters.Tests
 
                 // HIT (STALE): +1
                 // FAIL-SAFE: +1
-                // SET: +1
                 _ = await cache.GetOrSetAsync<int>("foo", _ => throw new Exception("Sloths are cool"));
 
                 // REMOVE: +1
@@ -280,7 +278,7 @@ namespace ZiggyCreatures.Caching.Fusion.Plugins.EventCounters.Tests
                 Assert.Equal(3, GetMetric(messages, SemanticConventions.Instance().CacheMissTagValue));
                 Assert.Equal(2, GetMetric(messages, SemanticConventions.Instance().CacheHitTagValue));
                 Assert.Equal(2, GetMetric(messages, SemanticConventions.Instance().CacheStaleHitTagValue));
-                Assert.Equal(3, GetMetric(messages, SemanticConventions.Instance().CacheSetTagValue));
+                Assert.Equal(1, GetMetric(messages, SemanticConventions.Instance().CacheSetTagValue));
                 Assert.Equal(2, GetMetric(messages, SemanticConventions.Instance().CacheRemovedTagValue));
                 Assert.Equal(2, GetMetric(messages, SemanticConventions.Instance().CacheFailSafeActivateTagValue));
             }
@@ -393,7 +391,6 @@ namespace ZiggyCreatures.Caching.Fusion.Plugins.EventCounters.Tests
 
                 // HIT (STALE): +1
                 // FAIL-SAFE: +1
-                // SET: +1
                 // STALE_REFRESH_ERROR: +1
                 _ = await cache.GetOrSetAsync<int>("foo", async _ =>
                 {
@@ -409,7 +406,7 @@ namespace ZiggyCreatures.Caching.Fusion.Plugins.EventCounters.Tests
 
                 Assert.Equal(0, GetMetric(messages, SemanticConventions.Instance().CacheHitTagValue));
                 Assert.Equal(2, GetMetric(messages, SemanticConventions.Instance().CacheFailSafeActivateTagValue));
-                Assert.Equal(3, GetMetric(messages, SemanticConventions.Instance().CacheSetTagValue));
+                Assert.Equal(2, GetMetric(messages, SemanticConventions.Instance().CacheSetTagValue));
                 Assert.Equal(2, GetMetric(messages, SemanticConventions.Instance().CacheStaleHitTagValue));
                 Assert.Equal(1, GetMetric(messages, SemanticConventions.Instance().CacheBackgroundRefreshedTagValue));
                 Assert.Equal(1, GetMetric(messages, SemanticConventions.Instance().CacheBackgroundFailedRefreshedTagValue));

--- a/tests/FusionCache.Plugins.Metrics.EventCounters.Tests/FusionCache.Plugins.Metrics.EventCounters.Tests.csproj
+++ b/tests/FusionCache.Plugins.Metrics.EventCounters.Tests/FusionCache.Plugins.Metrics.EventCounters.Tests.csproj
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.1.9" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.9.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Previously I expected a cache SET metric to trigger when a cache GetOrSetAsync's function threw an exception.   After the [backplane feature](https://github.com/jodydonetti/ZiggyCreatures.FusionCache/issues/11) was added in FusionCache this flaw in logic was exposed.  I think you can logically draw the parallel conclusion that when failsafe feature was not enabled it does not raise an event indicating cache was set.  So, I am updating the test to match what is the more correct behavior.