### PR TITLE
FusionCache:: Adaptive Cache feature updates

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,7 +2,7 @@ name: .NET
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, feature/adaptive_caching ]
   pull_request:
     branches: [ main ]
 

--- a/benchmarks/FusionCache.Plugins.Metrics.EventCounters.Benchmarks/FusionCache.Plugins.Metrics.EventCounters.Benchmarks.csproj
+++ b/benchmarks/FusionCache.Plugins.Metrics.EventCounters.Benchmarks/FusionCache.Plugins.Metrics.EventCounters.Benchmarks.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.10.0-preview1" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/AppMetricsPluginExampleDotNetCore/AppMetricsPluginExampleDotNetCore.csproj
+++ b/examples/AppMetricsPluginExampleDotNetCore/AppMetricsPluginExampleDotNetCore.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="App.Metrics.Reporting.TextFile" Version="4.3.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
-    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.10.0-preview1" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/AppMetricsPluginExampleFramework/AppMetricsPluginExampleFramework.csproj
+++ b/examples/AppMetricsPluginExampleFramework/AppMetricsPluginExampleFramework.csproj
@@ -406,7 +406,7 @@
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="ZiggyCreatures.FusionCache, Version=0.10.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ZiggyCreatures.FusionCache.0.10.0-preview1\lib\netstandard2.0\ZiggyCreatures.FusionCache.dll</HintPath>
+      <HintPath>..\..\packages\ZiggyCreatures.FusionCache.0.10.0\lib\netstandard2.0\ZiggyCreatures.FusionCache.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/examples/AppMetricsPluginExampleFramework/packages.config
+++ b/examples/AppMetricsPluginExampleFramework/packages.config
@@ -115,5 +115,5 @@
   <package id="System.Xml.ReaderWriter" version="4.3.1" targetFramework="net472" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net472" />
   <package id="WebGrease" version="1.6.0" targetFramework="net472" />
-  <package id="ZiggyCreatures.FusionCache" version="0.10.0-preview1" targetFramework="net472" />
+  <package id="ZiggyCreatures.FusionCache" version="0.10.0" targetFramework="net472" />
 </packages>

--- a/examples/AppMetricsPluginExampleFrameworkOnAspNetCore/AppMetricsPluginExampleFrameworkOnAspNetCore.csproj
+++ b/examples/AppMetricsPluginExampleFrameworkOnAspNetCore/AppMetricsPluginExampleFrameworkOnAspNetCore.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Serilog.Settings.AppSettings" Version="2.2.2" />
     <PackageReference Include="System.Text.Json" Version="6.0.3" />
-    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.10.0-preview1" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/EventCountersPluginExampleDotNetCore/EventCountersPluginExampleDotNetCore.csproj
+++ b/examples/EventCountersPluginExampleDotNetCore/EventCountersPluginExampleDotNetCore.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="InfluxDB.Client" Version="3.3.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
-    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.10.0-preview1" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FusionCache.Plugins.Metrics.AppMetrics/FusionCache.Plugins.Metrics.AppMetrics.csproj
+++ b/src/FusionCache.Plugins.Metrics.AppMetrics/FusionCache.Plugins.Metrics.AppMetrics.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="App.Metrics" Version="4.3.0" />
-    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.10.0-preview1" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FusionCache.Plugins.Metrics.EventCounters/FusionCache.Plugins.Metrics.EventCounters.csproj
+++ b/src/FusionCache.Plugins.Metrics.EventCounters/FusionCache.Plugins.Metrics.EventCounters.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.10.0-preview1" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/FusionCache.Plugins.Metrics.AppMetrics.Tests/FusionCache.Plugins.Metrics.AppMetrics.Tests.csproj
+++ b/tests/FusionCache.Plugins.Metrics.AppMetrics.Tests/FusionCache.Plugins.Metrics.AppMetrics.Tests.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.10.0-preview1" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/FusionCache.Plugins.Metrics.EventCounters.Tests/EventCountersTests.cs
+++ b/tests/FusionCache.Plugins.Metrics.EventCounters.Tests/EventCountersTests.cs
@@ -465,6 +465,8 @@ namespace ZiggyCreatures.Caching.Fusion.Plugins.EventCounters.Tests
 
                 // HIT (STALE): +1
                 cache.TryGet<int>("foo");
+                // HIT (STALE): +1
+                cache.TryGet<int>("foo");
 
                 // REMOVE HANDLERS
                 eventSource.Stop(cache);
@@ -475,7 +477,7 @@ namespace ZiggyCreatures.Caching.Fusion.Plugins.EventCounters.Tests
                 var messages = listener.Messages.ToList();
 
                 Assert.Equal(1, GetMetric(messages, SemanticConventions.Instance().CacheHitTagValue));
-                Assert.Equal(1, GetMetric(messages, SemanticConventions.Instance().CacheStaleHitTagValue));
+                Assert.Equal(2, GetMetric(messages, SemanticConventions.Instance().CacheStaleHitTagValue));
             }
         }
 
@@ -544,6 +546,15 @@ namespace ZiggyCreatures.Caching.Fusion.Plugins.EventCounters.Tests
                     return 42;
                 });
 
+                // HIT (STALE): +1
+                cache.GetOrSet<int>("foo", (ctx, _) =>
+                {
+                    Thread.Sleep(throttleDuration);
+                    // Duration overriden in factory from minutes to seconds.
+                    ctx.Options.SetDuration(adaptiveDuration).SetFailSafe(true);
+
+                    return 42;
+                });
 
                 // REMOVE HANDLERS
                 eventSource.Stop(cache);
@@ -555,7 +566,7 @@ namespace ZiggyCreatures.Caching.Fusion.Plugins.EventCounters.Tests
 
                 Assert.Equal(1, GetMetric(messages, SemanticConventions.Instance().CacheHitTagValue));
                 Assert.Equal(1, GetMetric(messages, SemanticConventions.Instance().CacheSetTagValue));
-                Assert.Equal(1, GetMetric(messages, SemanticConventions.Instance().CacheStaleHitTagValue));
+                Assert.Equal(2, GetMetric(messages, SemanticConventions.Instance().CacheStaleHitTagValue));
             }
         }
 

--- a/tests/FusionCache.Plugins.Metrics.EventCounters.Tests/FusionCache.Plugins.Metrics.EventCounters.Tests.csproj
+++ b/tests/FusionCache.Plugins.Metrics.EventCounters.Tests/FusionCache.Plugins.Metrics.EventCounters.Tests.csproj
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.10.0-preview1" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.10.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
FusionCache [Adaptive Caching](https://github.com/jodydonetti/ZiggyCreatures.FusionCache/releases/tag/v0.10.0) package update.  

- New tests added to demonstrate adative caching
- More assertions demonstrating the existence of a more accurate Stale Hit event when a cache goes stale and stays stale on subsequenct requests.